### PR TITLE
added graphql fragments for user

### DIFF
--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -90,35 +90,42 @@ export type User = {
   name: Scalars['String'];
 };
 
+export type RegularUserFragment = { __typename?: 'User', id: string, name: string, email: string };
+
 export type LoginMutationVariables = Exact<{
   email: Scalars['String'];
   password: Scalars['String'];
 }>;
 
 
-export type LoginMutation = { __typename?: 'Mutation', login?: { __typename?: 'User', name: string, id: string } | null | undefined };
+export type LoginMutation = { __typename?: 'Mutation', login?: { __typename?: 'User', id: string, name: string, email: string } | null | undefined };
 
 export type RegisterMutationVariables = Exact<{
   data: RegisterInput;
 }>;
 
 
-export type RegisterMutation = { __typename?: 'Mutation', register: { __typename?: 'User', name: string, email: string, id: string } };
+export type RegisterMutation = { __typename?: 'Mutation', register: { __typename?: 'User', id: string, name: string, email: string } };
 
 export type MeQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type MeQuery = { __typename?: 'Query', me?: { __typename?: 'User', id: string, name: string } | null | undefined };
+export type MeQuery = { __typename?: 'Query', me?: { __typename?: 'User', id: string, name: string, email: string } | null | undefined };
 
-
+export const RegularUserFragmentDoc = gql`
+    fragment RegularUser on User {
+  id
+  name
+  email
+}
+    `;
 export const LoginDocument = gql`
     mutation Login($email: String!, $password: String!) {
   login(email: $email, password: $password) {
-    name
-    id
+    ...RegularUser
   }
 }
-    `;
+    ${RegularUserFragmentDoc}`;
 
 export function useLoginMutation() {
   return Urql.useMutation<LoginMutation, LoginMutationVariables>(LoginDocument);
@@ -126,12 +133,10 @@ export function useLoginMutation() {
 export const RegisterDocument = gql`
     mutation Register($data: RegisterInput!) {
   register(data: $data) {
-    name
-    email
-    id
+    ...RegularUser
   }
 }
-    `;
+    ${RegularUserFragmentDoc}`;
 
 export function useRegisterMutation() {
   return Urql.useMutation<RegisterMutation, RegisterMutationVariables>(RegisterDocument);
@@ -139,11 +144,10 @@ export function useRegisterMutation() {
 export const MeDocument = gql`
     query Me {
   me {
-    id
-    name
+    ...RegularUser
   }
 }
-    `;
+    ${RegularUserFragmentDoc}`;
 
 export function useMeQuery(options: Omit<Urql.UseQueryArgs<MeQueryVariables>, 'query'> = {}) {
   return Urql.useQuery<MeQuery>({ query: MeDocument, ...options });

--- a/client/src/graphql/fragments/RegularUser.graphql
+++ b/client/src/graphql/fragments/RegularUser.graphql
@@ -1,0 +1,5 @@
+fragment RegularUser on User {
+  id
+  name
+  email
+}

--- a/client/src/graphql/mutations/login.graphql
+++ b/client/src/graphql/mutations/login.graphql
@@ -1,6 +1,5 @@
 mutation Login($email :String! , $password :String!){
   login(email : $email , password : $password){
-    name ,
-    id
+   ...RegularUser 
   }
 }

--- a/client/src/graphql/mutations/register.graphql
+++ b/client/src/graphql/mutations/register.graphql
@@ -1,7 +1,5 @@
-mutation Register($data : RegisterInput!){
-    register(data : $data){
-      name ,
-      email ,
-      id ,
-    }
+mutation Register($data: RegisterInput!) {
+  register(data: $data) {
+    ...RegularUser
   }
+}

--- a/client/src/graphql/queries/me.graphql
+++ b/client/src/graphql/queries/me.graphql
@@ -1,6 +1,5 @@
 query Me {
   me {
-    id
-    name
+    ...RegularUser
   }
 }


### PR DESCRIPTION
Graphql Fragments can be used to define the particular fields to query and it makes it a whole lot easier to change the structure of the query as we just need to update the fragment.